### PR TITLE
add schema validation for serverless >= 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ service: my-great-service
 provider:
   name: aws
   stage: test
-  tracing: true # enable tracing
   iamRoleStatements:
     - Effect: "Allow" # xray permissions (required)
       Action:
@@ -36,6 +35,10 @@ provider:
 
 plugins:
   - serverless-plugin-tracing
+
+custom:
+  serverless-plugin-tracing:
+    tracing: true # enable tracing
 
 functions:
   mainFunction: # inherits tracing settings from "provider"


### PR DESCRIPTION
Looks like as per the documentation [here](https://www.serverless.com/framework/docs/providers/aws/guide/plugins/#extending-validation-schema) that plugins can define properties in the `custom:` but not the `provider:` section of `serverless.yml`. Moreover plugin properties cannot be in the top level of `custom:`, but instead must be in a node one level down which is the namesake of the plugin.

Addresses #23 